### PR TITLE
drop tests support on Drupal <= 9.4 && add support of Drupal 10.2 & 11.0-dev

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,13 @@ jobs:
 
     strategy:
       matrix:
-        drupal_version: ['9.3', '9.4', '9.5', '10.0']
+        drupal_version: ['9.5', '10.0', '10.1', '10.2', '11.0']
         module: ['timesup']
         experimental: [ false ]
+        include:
+          - drupal_version: '11.0'
+            module: 'timesup'
+            experimental: true
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/styles.yml
+++ b/.github/workflows/styles.yml
@@ -9,10 +9,10 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.3'
+          php-version: '8.1'
           extensions: mbstring, intl, gd, xml, dom, json, fileinfo, curl, zip, iconv
-          tools: cs2pr, composer:v1
-      - uses: actions/checkout@v3
+          tools: cs2pr, composer:v2
+      - uses: actions/checkout@v4
       - run: composer install --prefer-dist
       - run: ./vendor/bin/phpcs ./ --report=checkstyle | cs2pr
 
@@ -23,10 +23,10 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.3'
+          php-version: '8.1'
           extensions: mbstring, intl, gd, xml, dom, json, fileinfo, curl, zip, iconv
-          tools: cs2pr, composer:v1, phpmd
-      - uses: actions/checkout@v3
+          tools: cs2pr, composer:v2, phpmd
+      - uses: actions/checkout@v4
       - run: composer install --prefer-dist
       - run: phpmd ./ text ./phpmd.xml --suffixes php,module,inc,install,test,profile,theme,css,info,txt --exclude *Test.php,*vendor/*
 
@@ -37,10 +37,10 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.3'
+          php-version: '8.1'
           extensions: mbstring, intl, gd, xml, dom, json, fileinfo, curl, zip, iconv
-          tools: cs2pr, composer:v1, phpcpd
-      - uses: actions/checkout@v3
+          tools: cs2pr, composer:v2, phpcpd
+      - uses: actions/checkout@v4
       - run: composer install --prefer-dist
       - run: phpcpd ./src --suffix .php --suffix .module --suffix .inc --suffix .install --suffix .test --suffix .profile --suffix .theme --suffix .css --suffix .info --suffix .txt --exclude *.md --exclude *.info.yml --exclude tests --exclude vendor/
 
@@ -48,7 +48,7 @@ jobs:
     name: PhpDeprecationDetector (phpdd)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: docker-compose -f docker-compose.yml pull --include-deps drupal
       - name: Build the docker-compose stack
         run: docker-compose -f docker-compose.yml build drupal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - add Drupal GitlabCI
+- add coverage of Drupal 10.2.x
+- add coverage of Drupal 11.0-dev
+
+### Removed
+- drop tests support on Drupal <= 9.4
 
 ## [2.0.0] - 2022-12-16
 ### Changed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,22 +27,22 @@ First of all, you need to have the following tools installed globally
 on your environment:
 
   * drush
-  * Latest dev release of Drupal 8.x/9.x/10.x.
+  * Latest dev release of Drupal 8.x/9.x/10.x/11.x.
   * docker
-  * docker-compose
+  * docker compose
 
 ### Project bootstrap
 
 Once run, you will be able to access to your fresh installed Drupal on `localhost::8888`.
 
-    docker-compose build --pull --build-arg BASE_IMAGE_TAG=9.3 drupal
+    docker compose build --pull --build-arg BASE_IMAGE_TAG=10.1 drupal
     (get a coffee, this will take some time...)
-    docker-compose up -d drupal
-    docker-compose exec -u www-data drupal drush site-install standard --db-url="mysql://drupal:drupal@db/drupal" --site-name=Example -y
+    docker compose up -d drupal
+    docker compose exec -u www-data drupal drush site-install standard --db-url="mysql://drupal:drupal@db/drupal" --site-name=Example -y
 
     # You may be interesed by reseting the admin passowrd of your Docker and install the module using those cmd.
-    docker-compose exec drupal drush user:password admin admin
-    docker-compose exec drupal drush en timesup
+    docker compose exec drupal drush user:password admin admin
+    docker compose exec drupal drush en timesup
 
 ## 🏆 Tests
 
@@ -50,7 +50,7 @@ We use the [Docker for Drupal Contrib images](https://hub.docker.com/r/wengerk/d
 
 Run testing by stopping at first failure using the following command:
 
-    docker-compose exec -u www-data drupal phpunit --group=timesup --no-coverage --stop-on-failure --configuration=/var/www/html/phpunit.xml
+    docker compose exec -u www-data drupal phpunit --group=timesup --no-coverage --stop-on-failure --configuration=/var/www/html/phpunit.xml
 
 ## 🚔 Check Drupal coding standards & Drupal best practices
 
@@ -68,7 +68,7 @@ The following Analyzer will be downloaded & installed as PHAR:
 
     ./scripts/hooks/post-commit
     # or run command on the container itself
-    docker-compose exec drupal bash
+    docker compose exec drupal bash
 
 #### Running Code Sniffer Drupal & DrupalPractice
 
@@ -80,13 +80,13 @@ violations.
 PHP_CodeSniffer is an essential development tool that ensures your code remains clean and consistent.
 
   ```
-  $ docker-compose exec drupal ./vendor/bin/phpcs ./web/modules/contrib/timesup/
+  $ docker compose exec drupal ./vendor/bin/phpcs ./web/modules/contrib/timesup/
   ```
 
 Automatically fix coding standards
 
   ```
-  $ docker-compose exec drupal ./vendor/bin/phpcbf ./web/modules/contrib/timesup/
+  $ docker compose exec drupal ./vendor/bin/phpcbf ./web/modules/contrib/timesup/
   ```
 
 #### Running PHP Mess Detector
@@ -96,7 +96,7 @@ https://github.com/phpmd/phpmd
 Detect overcomplicated expressions & Unused parameters, methods, properties.
 
   ```
-  $ docker-compose exec drupal phpmd ./web/modules/contrib/timesup/ text ./phpmd.xml \
+  $ docker compose exec drupal phpmd ./web/modules/contrib/timesup/ text ./phpmd.xml \
   --suffixes php,module,inc,install,test,profile,theme,css,info,txt --exclude *Test.php,*vendor/*
   ```
 
@@ -107,7 +107,7 @@ https://github.com/sebastianbergmann/phpcpd
 `phpcpd` is a Copy/Paste Detector (CPD) for PHP code.
 
   ```
-  $ docker-compose exec drupal phpcpd ./web/modules/contrib/timesup/src --suffix .php --suffix .module --suffix .inc --suffix .install --suffix .test --suffix .profile --suffix .theme --suffix .css --suffix .info --suffix .txt --exclude *.md --exclude *.info.yml --exclude tests --exclude vendor/
+  $ docker compose exec drupal phpcpd ./web/modules/contrib/timesup/src --suffix .php --suffix .module --suffix .inc --suffix .install --suffix .test --suffix .profile --suffix .theme --suffix .css --suffix .info --suffix .txt --exclude *.md --exclude *.info.yml --exclude tests --exclude vendor/
   ```
 
 #### Running PhpDeprecationDetector
@@ -117,7 +117,7 @@ https://github.com/wapmorgan/PhpDeprecationDetector
 A scanner that checks compatibility of your code with PHP interpreter versions.
 
   ```
-  $ docker-compose exec drupal phpdd ./web/modules/contrib/timesup/ \
+  $ docker compose exec drupal phpdd ./web/modules/contrib/timesup/ \
     --file-extensions php,module,inc,install,test,profile,theme,info --exclude vendor
   ```
 

--- a/README.md
+++ b/README.md
@@ -45,19 +45,16 @@ Timesup also expose a some less-relative cache invalidation.
 
 ## Times'up versions
 
-Times'up is only available for Drupal 8 !
-The module is ready to be used in Drupal 8, there are no known issues.
-
-This version should work with all Drupal 8 releases, and it is always
-recommended to keep Drupal core installations up to date.
+Times'up is available for Drupal 8, 9, 10 & Drupal 11 (dev) !
+The module is ready to be used in Drupal, there are no known issues.
 
 ## Dependencies
 
-The Drupal 8 version of Times'up requires nothing !
+The Drupal version of Times'up requires nothing !
 Feel free to use it.
 
 Times'up requires PHP 7.0+ to works properly. We recommend updating to at least
-PHP 7.2 if possible, and ideally PHP 7.4, which is supported as of Drupal 8.8.0.
+PHP 8.1 if possible, and ideally PHP 8.2, which is supported as of Drupal 10.x.
 
 ## Supporting organizations
 

--- a/composer.json
+++ b/composer.json
@@ -23,5 +23,10 @@
   "license": "GPL-2.0-or-later",
   "require-dev": {
     "drupal/coder": "^8.3.1"
+  },
+  "config": {
+    "allow-plugins": {
+      "dealerdirect/phpcodesniffer-composer-installer": true
+    }
   }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     restart: always
 
   db:
-    image: mariadb:10.3.7
+    image: mariadb:10.3.8
     environment:
       MYSQL_USER: drupal
       MYSQL_PASSWORD: drupal

--- a/timesup.info.yml
+++ b/timesup.info.yml
@@ -1,5 +1,5 @@
 name: Times'up
 description: 'Provides cache-tags to deal with time sensitive data.'
 type: module
-core_version_requirement: ^9.3 || ^10
+core_version_requirement: ^9.5 || ^10 || ^11
 package: Cache


### PR DESCRIPTION
### 💬 Description
drop tests support on Drupal <= 9.4 && add support of Drupal 10.2 & 11.0-dev
