### PR TITLE
add configuration settings  to enable or disable resolvers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        drupal_version: ['9.5', '10.0', '10.1', '10.2', '10.3']
+        drupal_version: ['9.5', '10.0', '10.1', '10.2', '10.3', '11.0']
         module: ['timesup']
         experimental: [ false ]
 
@@ -34,9 +34,13 @@ jobs:
 
     strategy:
       matrix:
-        drupal_version: ['9.5', '10.0', '10.1', '10.2', '11.0']
+        drupal_version: ['9.5', '10.0', '10.1', '10.2', '10.3', '11.0']
         module: [ 'timesup' ]
         experimental: [ false ]
+        exclude:
+          - drupal_version: '11.0'
+            module: 'timesup'
+            experimental: false
         include:
           - drupal_version: '11.0'
             module: 'timesup'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,41 @@ jobs:
         run: docker-compose -f docker-compose.yml run -u www-data drupal phpunit --no-coverage --group=${{ matrix.module }} --exclude-group=${{ matrix.module }}_functional --configuration=/var/www/html/phpunit.xml
         continue-on-error: ${{ matrix.experimental }}
 
+
+  tests-functional:
+    name: Functional Tests
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        drupal_version: ['9.5', '10.0', '10.1', '10.2', '11.0']
+        module: [ 'timesup' ]
+        experimental: [ false ]
+        include:
+          - drupal_version: '11.0'
+            module: 'timesup'
+            experimental: true
+
+    steps:
+      - uses: actions/checkout@v4
+      - run: docker-compose -f docker-compose.yml pull --include-deps drupal
+      - name: Build the docker-compose stack
+        run: docker-compose -f docker-compose.yml build --pull --build-arg BASE_IMAGE_TAG=${{ matrix.drupal_version }} drupal
+        continue-on-error: ${{ matrix.experimental }}
+      - name: Up a persistant Docker Container
+        run: docker-compose -f docker-compose.yml up -d drupal
+      - name: wait on Docker to be ready, especially Apache that takes many seconds to be up
+        run: docker-compose exec -T drupal wait-for-it drupal:80 -t 60
+      - name: wait on Docker to be ready, especially MariaDB that takes many seconds to be up
+        run: docker-compose exec -T drupal wait-for-it db:3306 -t 60
+      - name: Bootstrap Drupal
+        run: docker-compose -f docker-compose.yml exec -T -u www-data drupal drush site-install standard --db-url="mysql://drupal:drupal@db/drupal" -y
+        continue-on-error: ${{ matrix.experimental }}
+      - name: Run tests
+        run: docker-compose -f docker-compose.yml exec -T -u www-data drupal phpunit --no-coverage --group=${{ matrix.module }}_functional --configuration=/var/www/html/phpunit.xml
+        continue-on-error: ${{ matrix.experimental }}
+
   upgrade-status:
     name: Upgrade Status
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - add tests with drupal 10.3
+- add configuration settings `timesup.settings.resolvers` to enable or disable resolvers.
 
 ## [2.0.1] - 2024-03-01
 ### Fixed

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,25 @@
+# Upgrade guide
+
+## Upgrade from 2.0.1 to 2.1.x
+
+This guide is intended to describe the process of upgrading
+Times'up from version 2.0.1 to version 2.1.x.
+
+### Changes in configuration
+
+Running `drush updb` and exporting the changed configuration should be sufficient
+to convert to the new configuration structure.
+
+The `timesup.settings` configuration object has been introduced. This allows you to enable only the resolvers you actively use, reducing stress on cache and database invalidation.
+
+```yaml
+resolvers:
+  minutely: false
+  hourly: true
+  daily: true
+  midnight: true
+  weekly: true
+```
+
+
+

--- a/config/install/timesup.settings.yml
+++ b/config/install/timesup.settings.yml
@@ -1,0 +1,6 @@
+resolvers:
+  minutely: false
+  hourly: true
+  daily: true
+  midnight: true
+  weekly: true

--- a/config/schema/timesup.schema.yml
+++ b/config/schema/timesup.schema.yml
@@ -1,0 +1,23 @@
+timesup.settings:
+  type: config_object
+  label: Times'up settings
+  mapping:
+    resolvers:
+      type: mapping
+      label: 'Resolvers'
+      mapping:
+        minutely:
+          type: boolean
+          label: Enable minutely's Times'up cache resolvers
+        hourly:
+          type: boolean
+          label: Enable daily's Times'up cache resolvers
+        daily:
+          type: boolean
+          label: Enable daily's Times'up cache resolvers
+        midnight:
+          type: boolean
+          label: Enable midnight's Times'up cache resolvers
+        weekly:
+          type: boolean
+          label: Enable weekly's Times'up cache resolvers

--- a/config/schema/timesup.schema.yml
+++ b/config/schema/timesup.schema.yml
@@ -11,7 +11,7 @@ timesup.settings:
           label: Enable minutely's Times'up cache resolvers
         hourly:
           type: boolean
-          label: Enable daily's Times'up cache resolvers
+          label: Enable hourly Times'up cache resolvers
         daily:
           type: boolean
           label: Enable daily's Times'up cache resolvers

--- a/src/Form/SettingsForm.php
+++ b/src/Form/SettingsForm.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Drupal\timesup\Form;
+
+use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Times'up settings form.
+ */
+class SettingsForm extends ConfigFormBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'timesup_admin_settings';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $form = parent::buildForm($form, $form_state);
+    $resolvers = $this->config('timesup.settings')->get('resolvers');
+
+    // Submitted form values should be nested.
+    $form['#tree'] = TRUE;
+
+    $form['resolvers'] = [
+      '#type' => 'fieldset',
+      '#title' => $this->t('Resolvers'),
+      '#description' => $this->t('Please enable resolvers you actively use to avoid cache/database invalidation stress.'),
+    ];
+
+    $form['resolvers']['minutely'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Enable Minutely resolver.'),
+      '#default_value' => !empty($resolvers['minutely']),
+      '#description' => $this->t('Enable this feature will invalid cache-tags <code>timesup:minutely</code> every minutes (heavy stress sensitive).'),
+    ];
+
+    $form['resolvers']['hourly'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Enable Hourly resolver.'),
+      '#default_value' => !empty($resolvers['hourly']),
+      '#description' => $this->t('Enable this feature will invalid cache-tags <code>timesup:hourly</code> every hour.'),
+    ];
+
+    $form['resolvers']['daily'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Enable Daily resolver.'),
+      '#default_value' => !empty($resolvers['daily']),
+      '#description' => $this->t('Enable this feature will invalid cache-tags <code>timesup:daily</code> every day.'),
+    ];
+
+    $form['resolvers']['midnight'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Enable Midnight resolver.'),
+      '#default_value' => !empty($resolvers['midnight']),
+      '#description' => $this->t('Enable this feature will invalid cache-tags <code>timesup:midnight</code> every day at 00:00:00.'),
+    ];
+
+    $form['resolvers']['weekly'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Enable Weekly resolver.'),
+      '#default_value' => !empty($resolvers['weekly']),
+      '#description' => $this->t('Enable this feature will invalid cache-tags <code>timesup:weekly</code> every weeks.'),
+    ];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    parent::submitForm($form, $form_state);
+
+    $this->config('timesup.settings')
+      ->set('resolvers', [
+        'minutely' => (bool) $form_state->getValue(['resolvers', 'minutely']),
+        'hourly' => (bool) $form_state->getValue(['resolvers', 'hourly']),
+        'daily' => (bool) $form_state->getValue(['resolvers', 'daily']),
+        'midnight' => (bool) $form_state->getValue(['resolvers', 'midnight']),
+        'weekly' => (bool) $form_state->getValue(['resolvers', 'weekly']),
+      ])
+      ->save();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEditableConfigNames() {
+    return [
+      'timesup.settings',
+    ];
+  }
+
+}

--- a/src/Periodicity/DailyResolver.php
+++ b/src/Periodicity/DailyResolver.php
@@ -20,6 +20,13 @@ final class DailyResolver extends PeriodicityBaseResolver {
    * {@inheritdoc}
    */
   public function shouldApply(): bool {
+    $settings = $this->configFactory->get('timesup.settings');
+    $resolvers = $settings->get('resolvers');
+
+    if (!isset($resolvers['daily']) || !$resolvers['daily']) {
+      return FALSE;
+    }
+
     $last_run_per_day = $this->state->get($this->getLastRunKey());
     return !($this->time->getRequestTime() - $last_run_per_day < 86400);
   }

--- a/src/Periodicity/HourlyResolver.php
+++ b/src/Periodicity/HourlyResolver.php
@@ -20,6 +20,13 @@ final class HourlyResolver extends PeriodicityBaseResolver {
    * {@inheritdoc}
    */
   public function shouldApply(): bool {
+    $settings = $this->configFactory->get('timesup.settings');
+    $resolvers = $settings->get('resolvers');
+
+    if (!isset($resolvers['hourly']) || !$resolvers['hourly']) {
+      return FALSE;
+    }
+
     $last_run_per_week = $this->state->get($this->getLastRunKey());
     return !($this->time->getRequestTime() - $last_run_per_week < 3600);
   }

--- a/src/Periodicity/MidnightResolver.php
+++ b/src/Periodicity/MidnightResolver.php
@@ -23,6 +23,13 @@ class MidnightResolver extends PeriodicityBaseResolver {
    * {@inheritdoc}
    */
   public function shouldApply(): bool {
+    $settings = $this->configFactory->get('timesup.settings');
+    $resolvers = $settings->get('resolvers');
+
+    if (!isset($resolvers['midnight']) || !$resolvers['midnight']) {
+      return FALSE;
+    }
+
     $today_midnight = $this->getTodayMidnight();
     $last_run = $this->state->get($this->getLastRunKey());
     return $last_run <= $today_midnight->getTimestamp();

--- a/src/Periodicity/MinutelyResolver.php
+++ b/src/Periodicity/MinutelyResolver.php
@@ -20,6 +20,13 @@ final class MinutelyResolver extends PeriodicityBaseResolver {
    * {@inheritdoc}
    */
   public function shouldApply(): bool {
+    $settings = $this->configFactory->get('timesup.settings');
+    $resolvers = $settings->get('resolvers');
+
+    if (!isset($resolvers['minutely']) || !$resolvers['minutely']) {
+      return FALSE;
+    }
+
     $last_run_per_minute = $this->state->get($this->getLastRunKey());
     return !($this->time->getRequestTime() - $last_run_per_minute < 60);
   }

--- a/src/Periodicity/PeriodicityBaseResolver.php
+++ b/src/Periodicity/PeriodicityBaseResolver.php
@@ -4,6 +4,7 @@ namespace Drupal\timesup\Periodicity;
 
 use Drupal\Component\Datetime\TimeInterface;
 use Drupal\Core\Cache\CacheTagsInvalidatorInterface;
+use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\Core\State\StateInterface;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
@@ -21,6 +22,11 @@ abstract class PeriodicityBaseResolver implements PeriodicityResolverInterface {
    * @var \Drupal\Core\Cache\CacheTagsInvalidatorInterface
    */
   protected $cacheTagsInvalidator;
+
+  /**
+   * The config factory.
+   */
+  protected ConfigFactoryInterface $configFactory;
 
   /**
    * The state service.
@@ -48,6 +54,8 @@ abstract class PeriodicityBaseResolver implements PeriodicityResolverInterface {
    *
    * @param \Drupal\Core\Cache\CacheTagsInvalidatorInterface $cache_tags_invalidator
    *   The cache tags invalidator.
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The factory for configuration objects.
    * @param \Drupal\Core\State\StateInterface $state
    *   The state service.
    * @param \Drupal\Component\Datetime\TimeInterface $time
@@ -55,8 +63,9 @@ abstract class PeriodicityBaseResolver implements PeriodicityResolverInterface {
    * @param \Drupal\Core\Logger\LoggerChannelFactoryInterface $logger_factory
    *   The logger channel factory service.
    */
-  public function __construct(CacheTagsInvalidatorInterface $cache_tags_invalidator, StateInterface $state, TimeInterface $time, LoggerChannelFactoryInterface $logger_factory) {
+  public function __construct(CacheTagsInvalidatorInterface $cache_tags_invalidator, ConfigFactoryInterface $config_factory, StateInterface $state, TimeInterface $time, LoggerChannelFactoryInterface $logger_factory) {
     $this->cacheTagsInvalidator = $cache_tags_invalidator;
+    $this->configFactory = $config_factory;
     $this->state = $state;
     $this->time = $time;
     $this->logger = $logger_factory->get('timesup');

--- a/src/Periodicity/WeeklyResolver.php
+++ b/src/Periodicity/WeeklyResolver.php
@@ -20,6 +20,13 @@ final class WeeklyResolver extends PeriodicityBaseResolver {
    * {@inheritdoc}
    */
   public function shouldApply(): bool {
+    $settings = $this->configFactory->get('timesup.settings');
+    $resolvers = $settings->get('resolvers');
+
+    if (!isset($resolvers['weekly']) || !$resolvers['weekly']) {
+      return FALSE;
+    }
+
     $last_run_per_week = $this->state->get($this->getLastRunKey());
     return !($this->time->getRequestTime() - $last_run_per_week < 604800);
   }

--- a/tests/src/Functional/SettingsFormTest.php
+++ b/tests/src/Functional/SettingsFormTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Drupal\Tests\timesup\Functional;
+
+use Drupal\Tests\BrowserTestBase;
+
+/**
+ * @coversDefaultClass \Drupal\timesup\Form\SettingsForm
+ *
+ * @group timesup
+ * @group timesup_functional
+ */
+class SettingsFormTest extends BrowserTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'timesup',
+  ];
+
+  /**
+   * We use the minimal profile because we want to test local action links.
+   *
+   * @var string
+   */
+  protected $profile = 'minimal';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $defaultTheme = 'starterkit_theme';
+
+  /**
+   * Ensure the routing permissions works.
+   */
+  public function testAccessPermission() {
+    // Create a user whitout permission for tests.
+    $account = $this->drupalCreateUser();
+    $this->drupalLogin($account);
+
+    $this->drupalGet('admin/config/timesup/settings');
+    $this->assertSession()->statusCodeEquals(403);
+
+    // Create another user with propre permission for tests.
+    $account = $this->drupalCreateUser(['administer timesup']);
+    $this->drupalLogin($account);
+
+    $this->drupalGet('admin/config/timesup/settings');
+    $this->assertSession()->statusCodeEquals(200);
+  }
+
+  /**
+   * Ensure the configuration storage works as expected.
+   */
+  public function testConfigurationPersistance() {
+    $settings = $this->container->get('config.factory')->getEditable('timesup.settings');
+    $settings->set('resolvers', [
+      'minutely' => FALSE,
+      'hourly' => FALSE,
+      'daily' => TRUE,
+      'midnight' => TRUE,
+      'weekly' => TRUE,
+    ])->save();
+
+    // Create another user with propre permission for tests.
+    $account = $this->drupalCreateUser(['administer timesup']);
+    $this->drupalLogin($account);
+
+    $this->drupalGet('admin/config/timesup/settings');
+    $this->assertSession()->statusCodeEquals(200);
+
+    $this->assertSession()->checkboxNotChecked('resolvers[minutely]');
+    $this->assertSession()->checkboxNotChecked('resolvers[hourly]');
+    $this->assertSession()->checkboxChecked('resolvers[daily]');
+    $this->assertSession()->checkboxChecked('resolvers[midnight]');
+    $this->assertSession()->checkboxChecked('resolvers[weekly]');
+
+    // Checking the minutely resolver should be presisted.
+    $this->submitForm(["resolvers[minutely]" => TRUE, "resolvers[weekly]" => FALSE], 'Save');
+
+    $this->drupalGet('admin/config/timesup/settings');
+    $this->assertSession()->checkboxChecked('resolvers[minutely]');
+    $this->assertSession()->checkboxNotChecked('resolvers[hourly]');
+    $this->assertSession()->checkboxChecked('resolvers[daily]');
+    $this->assertSession()->checkboxChecked('resolvers[midnight]');
+    $this->assertSession()->checkboxNotChecked('resolvers[weekly]');
+  }
+
+}

--- a/tests/src/Unit/Resolver/DailyResolverTest.php
+++ b/tests/src/Unit/Resolver/DailyResolverTest.php
@@ -4,6 +4,8 @@ namespace Drupal\Tests\timesup\Unit\Resolver;
 
 use Drupal\Component\Datetime\TimeInterface;
 use Drupal\Core\Cache\CacheTagsInvalidatorInterface;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Config\ImmutableConfig;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\Core\Logger\LoggerChannelInterface;
 use Drupal\Core\State\StateInterface;
@@ -41,6 +43,20 @@ class DailyResolverTest extends UnitTestCase {
   protected $state;
 
   /**
+   * The config factory service.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
+  protected $configFactory;
+
+  /**
+   * The mocked configuration object timesup.settings.
+   *
+   * @var \Drupal\Core\Config\ImmutableConfig
+   */
+  protected $settings;
+
+  /**
    * The logger.
    *
    * @var \Psr\Log\LoggerInterface
@@ -68,6 +84,11 @@ class DailyResolverTest extends UnitTestCase {
     parent::setUp();
     $this->cacheTagsInvalidator = $this->createMock(CacheTagsInvalidatorInterface::class);
 
+    // Create a mock config factory and config object.
+    $this->configFactory = $this->createMock(ConfigFactoryInterface::class);
+    $this->settings = $this->createMock(ImmutableConfig::class);
+    $this->configFactory->method('get')->with('timesup.settings')->willReturn($this->settings);
+
     $this->state = $this->createMock(StateInterface::class);
 
     $this->time = $this->createMock(TimeInterface::class);
@@ -83,7 +104,7 @@ class DailyResolverTest extends UnitTestCase {
    * @covers ::getCacheTags
    */
   public function testGetCacheTags() {
-    $resolver = new DailyResolver($this->cacheTagsInvalidator, $this->state, $this->time, $this->loggerFactory);
+    $resolver = new DailyResolver($this->cacheTagsInvalidator, $this->configFactory, $this->state, $this->time, $this->loggerFactory);
     $tags = $this->invokeMethod($resolver, 'getCacheTags');
     $this->assertSame(['timesup', 'timesup:daily'], $tags);
   }
@@ -92,9 +113,25 @@ class DailyResolverTest extends UnitTestCase {
    * @covers ::getLastRunKey
    */
   public function testGetLastRunKey() {
-    $resolver = new DailyResolver($this->cacheTagsInvalidator, $this->state, $this->time, $this->loggerFactory);
+    $resolver = new DailyResolver($this->cacheTagsInvalidator, $this->configFactory, $this->state, $this->time, $this->loggerFactory);
     $key = $this->invokeMethod($resolver, 'getLastRunKey');
     $this->assertEquals('timesup.last_run.DailyResolver', $key);
+  }
+
+  /**
+   * @covers ::shouldApply
+   */
+  public function testShouldApplySettingsDisabled() {
+    $this->settings->expects($this->once())
+      ->method('get')->with('resolvers')->willReturn(['daily' => FALSE]);
+
+    $this->state->expects($this->never())
+      ->method('get')->with('timesup.last_run.DailyResolver');
+    $this->time->expects($this->never())
+      ->method('getRequestTime');
+
+    $resolver = new DailyResolver($this->cacheTagsInvalidator, $this->configFactory, $this->state, $this->time, $this->loggerFactory);
+    $this->assertFalse($resolver->shouldApply());
   }
 
   /**
@@ -103,12 +140,15 @@ class DailyResolverTest extends UnitTestCase {
    * @dataProvider shouldApplyProvider
    */
   public function testShouldApply($request_time, $last_run, $expected) {
+    $this->settings->expects($this->once())
+      ->method('get')->with('resolvers')->willReturn(['daily' => TRUE]);
+
     $this->state->expects($this->once())
       ->method('get')->with('timesup.last_run.DailyResolver')->willReturn($last_run);
     $this->time->expects($this->once())
       ->method('getRequestTime')->willReturn($request_time);
 
-    $resolver = new DailyResolver($this->cacheTagsInvalidator, $this->state, $this->time, $this->loggerFactory);
+    $resolver = new DailyResolver($this->cacheTagsInvalidator, $this->configFactory, $this->state, $this->time, $this->loggerFactory);
     $this->assertEquals($expected, $resolver->shouldApply());
   }
 
@@ -142,7 +182,7 @@ class DailyResolverTest extends UnitTestCase {
     $this->logger->expects($this->once())
       ->method('notice')->with("Purging Time's up time-sensitive cache-tags: timesup, timesup:daily.");
 
-    $resolver = new DailyResolver($this->cacheTagsInvalidator, $this->state, $this->time, $this->loggerFactory);
+    $resolver = new DailyResolver($this->cacheTagsInvalidator, $this->configFactory, $this->state, $this->time, $this->loggerFactory);
     $resolver->purge();
   }
 

--- a/tests/src/Unit/Resolver/MinutelyResolverTest.php
+++ b/tests/src/Unit/Resolver/MinutelyResolverTest.php
@@ -4,6 +4,8 @@ namespace Drupal\Tests\timesup\Unit\Resolver;
 
 use Drupal\Component\Datetime\TimeInterface;
 use Drupal\Core\Cache\CacheTagsInvalidatorInterface;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Config\ImmutableConfig;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\Core\Logger\LoggerChannelInterface;
 use Drupal\Core\State\StateInterface;
@@ -41,6 +43,20 @@ class MinutelyResolverTest extends UnitTestCase {
   protected $state;
 
   /**
+   * The config factory service.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
+  protected $configFactory;
+
+  /**
+   * The mocked configuration object timesup.settings.
+   *
+   * @var \Drupal\Core\Config\ImmutableConfig
+   */
+  protected $settings;
+
+  /**
    * The logger.
    *
    * @var \Psr\Log\LoggerInterface
@@ -68,6 +84,11 @@ class MinutelyResolverTest extends UnitTestCase {
     parent::setUp();
     $this->cacheTagsInvalidator = $this->createMock(CacheTagsInvalidatorInterface::class);
 
+    // Create a mock config factory and config object.
+    $this->configFactory = $this->createMock(ConfigFactoryInterface::class);
+    $this->settings = $this->createMock(ImmutableConfig::class);
+    $this->configFactory->method('get')->with('timesup.settings')->willReturn($this->settings);
+
     $this->state = $this->createMock(StateInterface::class);
 
     $this->time = $this->createMock(TimeInterface::class);
@@ -83,7 +104,7 @@ class MinutelyResolverTest extends UnitTestCase {
    * @covers ::getCacheTags
    */
   public function testGetCacheTags() {
-    $resolver = new MinutelyResolver($this->cacheTagsInvalidator, $this->state, $this->time, $this->loggerFactory);
+    $resolver = new MinutelyResolver($this->cacheTagsInvalidator, $this->configFactory, $this->state, $this->time, $this->loggerFactory);
     $tags = $this->invokeMethod($resolver, 'getCacheTags');
     $this->assertSame(['timesup', 'timesup:minutely'], $tags);
   }
@@ -92,9 +113,25 @@ class MinutelyResolverTest extends UnitTestCase {
    * @covers ::getLastRunKey
    */
   public function testGetLastRunKey() {
-    $resolver = new MinutelyResolver($this->cacheTagsInvalidator, $this->state, $this->time, $this->loggerFactory);
+    $resolver = new MinutelyResolver($this->cacheTagsInvalidator, $this->configFactory, $this->state, $this->time, $this->loggerFactory);
     $key = $this->invokeMethod($resolver, 'getLastRunKey');
     $this->assertEquals('timesup.last_run.MinutelyResolver', $key);
+  }
+
+  /**
+   * @covers ::shouldApply
+   */
+  public function testShouldApplySettingsDisabled() {
+    $this->settings->expects($this->once())
+      ->method('get')->with('resolvers')->willReturn(['minutely' => FALSE]);
+
+    $this->state->expects($this->never())
+      ->method('get')->with('timesup.last_run.MinutelyResolver');
+    $this->time->expects($this->never())
+      ->method('getRequestTime');
+
+    $resolver = new MinutelyResolver($this->cacheTagsInvalidator, $this->configFactory, $this->state, $this->time, $this->loggerFactory);
+    $this->assertFalse($resolver->shouldApply());
   }
 
   /**
@@ -103,12 +140,15 @@ class MinutelyResolverTest extends UnitTestCase {
    * @dataProvider shouldApplyProvider
    */
   public function testShouldApply($request_time, $last_run, $expected) {
+    $this->settings->expects($this->once())
+      ->method('get')->with('resolvers')->willReturn(['minutely' => TRUE]);
+
     $this->state->expects($this->once())
       ->method('get')->with('timesup.last_run.MinutelyResolver')->willReturn($last_run);
     $this->time->expects($this->once())
       ->method('getRequestTime')->willReturn($request_time);
 
-    $resolver = new MinutelyResolver($this->cacheTagsInvalidator, $this->state, $this->time, $this->loggerFactory);
+    $resolver = new MinutelyResolver($this->cacheTagsInvalidator, $this->configFactory, $this->state, $this->time, $this->loggerFactory);
     $this->assertEquals($expected, $resolver->shouldApply());
   }
 
@@ -144,7 +184,7 @@ class MinutelyResolverTest extends UnitTestCase {
     $this->logger->expects($this->once())
       ->method('notice')->with("Purging Time's up time-sensitive cache-tags: timesup, timesup:minutely.");
 
-    $resolver = new MinutelyResolver($this->cacheTagsInvalidator, $this->state, $this->time, $this->loggerFactory);
+    $resolver = new MinutelyResolver($this->cacheTagsInvalidator, $this->configFactory, $this->state, $this->time, $this->loggerFactory);
     $resolver->purge();
   }
 

--- a/tests/src/Unit/Resolver/WeeklyResolverTest.php
+++ b/tests/src/Unit/Resolver/WeeklyResolverTest.php
@@ -4,6 +4,8 @@ namespace Drupal\Tests\timesup\Unit\Resolver;
 
 use Drupal\Component\Datetime\TimeInterface;
 use Drupal\Core\Cache\CacheTagsInvalidatorInterface;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Config\ImmutableConfig;
 use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\Core\Logger\LoggerChannelInterface;
 use Drupal\Core\State\StateInterface;
@@ -41,6 +43,20 @@ class WeeklyResolverTest extends UnitTestCase {
   protected $state;
 
   /**
+   * The config factory service.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
+  protected $configFactory;
+
+  /**
+   * The mocked configuration object timesup.settings.
+   *
+   * @var \Drupal\Core\Config\ImmutableConfig
+   */
+  protected $settings;
+
+  /**
    * The logger.
    *
    * @var \Psr\Log\LoggerInterface
@@ -68,6 +84,11 @@ class WeeklyResolverTest extends UnitTestCase {
     parent::setUp();
     $this->cacheTagsInvalidator = $this->createMock(CacheTagsInvalidatorInterface::class);
 
+    // Create a mock config factory and config object.
+    $this->configFactory = $this->createMock(ConfigFactoryInterface::class);
+    $this->settings = $this->createMock(ImmutableConfig::class);
+    $this->configFactory->method('get')->with('timesup.settings')->willReturn($this->settings);
+
     $this->state = $this->createMock(StateInterface::class);
 
     $this->time = $this->createMock(TimeInterface::class);
@@ -83,7 +104,7 @@ class WeeklyResolverTest extends UnitTestCase {
    * @covers ::getCacheTags
    */
   public function testGetCacheTags() {
-    $resolver = new WeeklyResolver($this->cacheTagsInvalidator, $this->state, $this->time, $this->loggerFactory);
+    $resolver = new WeeklyResolver($this->cacheTagsInvalidator, $this->configFactory, $this->state, $this->time, $this->loggerFactory);
     $tags = $this->invokeMethod($resolver, 'getCacheTags');
     $this->assertSame(['timesup', 'timesup:weekly'], $tags);
   }
@@ -92,9 +113,25 @@ class WeeklyResolverTest extends UnitTestCase {
    * @covers ::getLastRunKey
    */
   public function testGetLastRunKey() {
-    $resolver = new WeeklyResolver($this->cacheTagsInvalidator, $this->state, $this->time, $this->loggerFactory);
+    $resolver = new WeeklyResolver($this->cacheTagsInvalidator, $this->configFactory, $this->state, $this->time, $this->loggerFactory);
     $key = $this->invokeMethod($resolver, 'getLastRunKey');
     $this->assertEquals('timesup.last_run.WeeklyResolver', $key);
+  }
+
+  /**
+   * @covers ::shouldApply
+   */
+  public function testShouldApplySettingsDisabled() {
+    $this->settings->expects($this->once())
+      ->method('get')->with('resolvers')->willReturn(['weekly' => FALSE]);
+
+    $this->state->expects($this->never())
+      ->method('get')->with('timesup.last_run.WeeklyResolver');
+    $this->time->expects($this->never())
+      ->method('getRequestTime');
+
+    $resolver = new WeeklyResolver($this->cacheTagsInvalidator, $this->configFactory, $this->state, $this->time, $this->loggerFactory);
+    $this->assertFalse($resolver->shouldApply());
   }
 
   /**
@@ -103,12 +140,15 @@ class WeeklyResolverTest extends UnitTestCase {
    * @dataProvider shouldApplyProvider
    */
   public function testShouldApply($request_time, $last_run, $expected) {
+    $this->settings->expects($this->once())
+      ->method('get')->with('resolvers')->willReturn(['weekly' => TRUE]);
+
     $this->state->expects($this->once())
       ->method('get')->with('timesup.last_run.WeeklyResolver')->willReturn($last_run);
     $this->time->expects($this->once())
       ->method('getRequestTime')->willReturn($request_time);
 
-    $resolver = new WeeklyResolver($this->cacheTagsInvalidator, $this->state, $this->time, $this->loggerFactory);
+    $resolver = new WeeklyResolver($this->cacheTagsInvalidator, $this->configFactory, $this->state, $this->time, $this->loggerFactory);
     $this->assertEquals($expected, $resolver->shouldApply());
   }
 
@@ -146,7 +186,7 @@ class WeeklyResolverTest extends UnitTestCase {
     $this->logger->expects($this->once())
       ->method('notice')->with("Purging Time's up time-sensitive cache-tags: timesup, timesup:weekly.");
 
-    $resolver = new WeeklyResolver($this->cacheTagsInvalidator, $this->state, $this->time, $this->loggerFactory);
+    $resolver = new WeeklyResolver($this->cacheTagsInvalidator, $this->configFactory, $this->state, $this->time, $this->loggerFactory);
     $resolver->purge();
   }
 

--- a/timesup.info.yml
+++ b/timesup.info.yml
@@ -3,3 +3,4 @@ description: 'Provides cache-tags to deal with time sensitive data.'
 type: module
 core_version_requirement: ^9.5 || ^10 || ^11
 package: Cache
+configure: timesup.settings

--- a/timesup.install
+++ b/timesup.install
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * @file
+ * Installation functions for the Times'up module.
+ */
+
+/**
+ * Add configuration settings to enable or disable Resolvers.
+ *
+ * NOTE: This update hook changes the 2.1.x config structure.
+ * Allowing to enable or disable each resolver independently.
+ */
+function timesup_update_8001() {
+  // Get module configuration.
+  $config_factory = \Drupal::configFactory();
+  $config = $config_factory->getEditable('timesup.settings');
+
+  // Set hosts.
+  $config->set('resolvers', [
+    'minutely' => 1,
+    'hourly' => 1,
+    'daily' => 1,
+    'midnight' => 1,
+    'weekly' => 1,
+  ]);
+
+  // Save the configuration.
+  $config->save();
+}

--- a/timesup.links.menu.yml
+++ b/timesup.links.menu.yml
@@ -1,0 +1,5 @@
+timesup.settings:
+  title: Times'up
+  route_name: timesup.settings
+  description: Configure features of Times'up.
+  parent: system.admin_config_system

--- a/timesup.permissions.yml
+++ b/timesup.permissions.yml
@@ -1,0 +1,2 @@
+'administer timesup':
+  title: Administer Times'up

--- a/timesup.routing.yml
+++ b/timesup.routing.yml
@@ -1,0 +1,9 @@
+timesup.settings:
+  path: '/admin/config/timesup/settings'
+  defaults:
+    _form: '\Drupal\timesup\Form\SettingsForm'
+    _title: 'Settings'
+  requirements:
+    _permission: 'administer timesup'
+  options:
+    _admin_route: TRUE

--- a/timesup.services.yml
+++ b/timesup.services.yml
@@ -7,7 +7,7 @@ services:
   timesup.periodicity_resolver.base:
     private: true
     class: Drupal\timesup\Periodicity\PeriodicityBaseResolver
-    arguments: ['@cache_tags.invalidator', '@state', '@datetime.time', '@logger.factory']
+    arguments: ['@cache_tags.invalidator', '@config.factory', '@state', '@datetime.time', '@logger.factory']
 
   timesup.periodicity_resolver.minutely:
     class: Drupal\timesup\Periodicity\MinutelyResolver


### PR DESCRIPTION
### 💬 Description
add configuration settings  to enable or disable resolvers

### 🔢 To Review
1. Use the new Configuration settings form on `admin/config/timesup/settings`

<img width="1125" alt="Screenshot 2024-03-12 at 16 54 42" src="https://github.com/antistatique/drupal-timesup/assets/1841592/51ec7f06-dde6-49f6-9d53-d35fab7decde">

2. The disabled resolver should never be purged to avoid database stressing 

- [x] Update the "Unreleased" section of the `CHANGELOG.md` with [chan](https://github.com/geut/chan/tree/main/packages/chan)
