### PR TITLE
add official stable support for drupal 10.4 & 11.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,11 +12,14 @@ jobs:
 
     strategy:
       matrix:
-        drupal_version: ['9.5', '10.0', '10.1', '10.2', '10.3', '11.0']
+        drupal_version: ['9.5', '10.0', '10.1', '10.2', '10.3', '10.4', '11.0', '11.1']
         module: ['timesup']
         experimental: [ false ]
         include:
-          - drupal_version: '11.1'
+          - drupal_version: '10.5'
+            module: 'timesup'
+            experimental: true
+          - drupal_version: '11.2'
             module: 'timesup'
             experimental: true
 
@@ -38,11 +41,14 @@ jobs:
 
     strategy:
       matrix:
-        drupal_version: ['9.5', '10.0', '10.1', '10.2', '10.3', '11.0']
+        drupal_version: ['9.5', '10.0', '10.1', '10.2', '10.3', '10.4', '11.0', '11.1']
         module: [ 'timesup' ]
         experimental: [ false ]
         include:
-          - drupal_version: '11.1'
+          - drupal_version: '10.5'
+            module: 'timesup'
+            experimental: true
+          - drupal_version: '11.2'
             module: 'timesup'
             experimental: true
 
@@ -71,7 +77,7 @@ jobs:
 
     strategy:
       matrix:
-        drupal_version: ['9.5']
+        drupal_version: ['10.4']
         module: ['timesup']
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- add official stable support for drupal 10.4
+- add official stable support for drupal 11.1
 
 ## [2.0.3] - 2024-08-20
 ### Changed


### PR DESCRIPTION
### 💬 Description
add official stable support for drupal 10.4 & 11.1

- [x] Update the "Unreleased" section of the `CHANGELOG.md` with [chan](https://github.com/geut/chan/tree/main/packages/chan)
