### PR TITLE
drop support of Drupal 9.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        drupal_version: ['9.5', '10.0', '10.1', '10.2', '10.3', '10.4', '11.0', '11.1']
+        drupal_version: ['10.0', '10.1', '10.2', '10.3', '10.4', '11.0', '11.1']
         module: ['timesup']
         experimental: [ false ]
         include:
@@ -41,7 +41,7 @@ jobs:
 
     strategy:
       matrix:
-        drupal_version: ['9.5', '10.0', '10.1', '10.2', '10.3', '10.4', '11.0', '11.1']
+        drupal_version: ['10.0', '10.1', '10.2', '10.3', '10.4', '11.0', '11.1']
         module: [ 'timesup' ]
         experimental: [ false ]
         include:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -32,14 +32,12 @@ variables:
   SKIP_ESLINT: '1'
   # Opt in to testing current minor against max supported PHP version.
   OPT_IN_TEST_MAX_PHP: '1'
-  # Opt in to testing previous & next minor (Drupal 10.2.x and 10.4.x).
+  # Opt in to testing previous minor (Drupal 11.0.3) & next minor (Drupal 11.2-dev).
   OPT_IN_TEST_PREVIOUS_MINOR: '1'
   OPT_IN_TEST_NEXT_MINOR: '1'
-  # Opt in to testing $CORE_PREVIOUS_MAJOR (currently Drupal 9.5).
+  # Opt in to testing $CORE_PREVIOUS_MAJOR (currently Drupal 10.4.6).
   OPT_IN_TEST_PREVIOUS_MAJOR: '1'
-  # The current branch of the module requires PHP >=8.1 minimum.
-  CORE_PREVIOUS_PHP_MIN: '8.1'
-  # Opt in to testing $CORE_MAJOR_DEVELOPMENT (currently Drupal 11).
+  # Opt in to testing $CORE_MAJOR_DEVELOPMENT (currently Drupal 12).
   OPT_IN_TEST_NEXT_MAJOR: '1'
 
 # This module wants to strictly comply with Drupal's coding standards.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Removed
 - drop support of Drupal 9.x
+- remove scanning CSS/JS with phpcs (deprecated and support will be removed in PHP_CodeSniffer 4.0)
 
 ## [2.0.4] - 2025-03-20
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Removed
+- drop support of Drupal 9.x
 
 ## [2.0.4] - 2025-03-20
 ### Added

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Timesup also expose a some less-relative cache invalidation.
 
 ## Times'up versions
 
-Times'up is available for Drupal 8, 9, 10 & Drupal 11 (dev) !
+Times'up is available for Drupal 8, 9, 10 & Drupal 11 !
 The module is ready to be used in Drupal, there are no known issues.
 
 ## Dependencies

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -6,7 +6,7 @@
   <arg name="basepath" value="."/>
   <arg name="cache" value=".phpcs-cache"/>
   <arg name="colors"/>
-  <arg name="extensions" value="php,module,inc,install,test,profile,theme,css,info,txt"/>
+  <arg name="extensions" value="php,inc,module,install,info,test,profile,theme"/>
 
   <exclude-pattern>*\.(md|info\.yml)$</exclude-pattern>>
   <exclude-pattern>*/vendor/*</exclude-pattern>>

--- a/timesup.info.yml
+++ b/timesup.info.yml
@@ -1,6 +1,6 @@
 name: Times'up
 description: 'Provides cache-tags to deal with time sensitive data.'
 type: module
-core_version_requirement: ^9.5 || ^10 || ^11
+core_version_requirement: ^10 || ^11
 package: Cache
 configure: timesup.settings


### PR DESCRIPTION
### 💬 Description
drop support of Drupal 9.x

- [x] Update the "Unreleased" section of the `CHANGELOG.md` with [chan](https://github.com/geut/chan/tree/main/packages/chan)
